### PR TITLE
feat: add Soniox speech recognition

### DIFF
--- a/defaults/settings.json
+++ b/defaults/settings.json
@@ -155,8 +155,6 @@
       "endpointDetection": false,
       "cleanup": true,
       "audioFormat": "auto",
-      "proxy": "temporary_key",
-      "tempKeyExpiry": 600,
       "speakerDiarization": false
     }
   },

--- a/src/settings/SettingsSTT.vue
+++ b/src/settings/SettingsSTT.vue
@@ -135,19 +135,6 @@
         <label>Cleanup after async transcription</label>
       </div> -->
 
-      <div class="form-field">
-        <label>Realtime security mode</label>
-        <select v-model="store.config.stt.soniox.proxy">
-          <option value="temporary_key">temporary_key (default)</option>
-          <option value="proxy_stream">proxy_stream (own backend proxy)</option>
-        </select>
-      </div>
-
-      <div v-if="store.config.stt.soniox.proxy === 'temporary_key'" class="form-field">
-        <label>Temporary key expiry (seconds)</label>
-        <input type="number" v-model.number="store.config.stt.soniox.tempKeyExpiry" min="30" />
-      </div>
-    
     </template>
 
     <div class="form-field">

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -230,8 +230,6 @@ export type STTConfig = {
     endpointDetection?: boolean
     cleanup?: boolean
     audioFormat?: string
-    proxy?: 'temporary_key' | 'proxy_stream'
-    tempKeyExpiry?: number
     speakerDiarization?: boolean
   }
   //silenceAction: SilenceAction

--- a/src/voice/stt.ts
+++ b/src/voice/stt.ts
@@ -101,7 +101,7 @@ export const getSTTEngines = () => {
     //{ id: 'huggingface', label: engineNames.huggingface },
     { id: 'groq', label: engineNames.groq },
     { id: 'mistralai', label: engineNames.mistralai },
-    // { id: 'soniox', label: engineNames.soniox },
+    { id: 'soniox', label: engineNames.soniox },
     { id: 'whisper', label: engineNames.whisper },
     { id: 'custom', label: 'Custom OpenAI' },
   ]

--- a/tests/screens/settings_voice.test.ts
+++ b/tests/screens/settings_voice.test.ts
@@ -97,6 +97,14 @@ test('stt settings', async () => {
   expect(store.config.stt.engine).toBe('whisper')
   expect(store.config.stt.model).toBe(whisper2.element.value)
 
+  // soniox
+  await stt.find('select[name=engine]').setValue('soniox')
+  expect(store.config.stt.engine).toBe('soniox')
+  expect(stt.find<HTMLSelectElement>('select[name=model]').element.value).toBe('stt-async-preview')
+  const soniox2 = stt.find('select[name=model]').findAll('option')[1]
+  await stt.find<HTMLSelectElement>('select[name=model]').setValue(soniox2.element.value)
+  expect(store.config.stt.model).toBe(soniox2.element.value)
+
   // custom
   await stt.find('select[name=engine]').setValue('custom')
   expect(stt.find<HTMLSelectElement>('select[name=model]').exists()).toBe(false)

--- a/tests/unit/stt-soniox.test.ts
+++ b/tests/unit/stt-soniox.test.ts
@@ -11,8 +11,6 @@ const makeConfig = (overrides: any = {}) => ({
       endpointDetection: false,
       cleanup: true,
       audioFormat: 'auto',
-      proxy: 'temporary_key',
-      tempKeyExpiry: 60,
     },
   },
   engines: {

--- a/tests/unit/stt.test.ts
+++ b/tests/unit/stt.test.ts
@@ -11,6 +11,7 @@ import STTMistral from '../../src/voice/stt-mistral'
 import STTNvidia from '../../src/voice/stt-nvidia'
 import STTOpenAI from '../../src/voice/stt-openai'
 import STTSpeechmatics from '../../src/voice/stt-speechmatics'
+import STTSoniox from '../../src/voice/stt-soniox'
 import STTWhisper from '../../src/voice/stt-whisper'
 import { fal } from '@fal-ai/client'
 import { Configuration } from '../../src/types/config'
@@ -186,6 +187,7 @@ test('Requires download', () => {
   expect(requiresDownload('openai')).toBe(false)
   expect(requiresDownload('groq')).toBe(false)
   expect(requiresDownload('whisper')).toBe(true)
+  expect(requiresDownload('soniox')).toBe(false)
 })
 
 test('Instantiates OpenAI by default', async () => {
@@ -344,6 +346,22 @@ test('Instantiates Speechmatics', async () => {
   expect(engine.requiresDownload()).toBe(false)
   await engine.initialize(initCallback)
   expect(initCallback).toHaveBeenLastCalledWith({ task: 'speechmatics', status: 'ready', model: expect.any(String) })
+  await expect(engine.transcribe(new Blob())).rejects.toThrowError()
+})
+
+test('Instantiates Soniox', async () => {
+  store.config.stt.engine = 'soniox'
+  const engine = getSTTEngine(store.config)
+  expect(engine).toBeDefined()
+  expect(engine).toBeInstanceOf(STTSoniox)
+  expect(engine.isStreamingModel('stt-rt-preview')).toBe(true)
+  expect(engine).toHaveProperty('startStreaming')
+  expect(engine).toHaveProperty('sendAudioChunk')
+  expect(engine).toHaveProperty('endStreaming')
+  expect(engine.isReady()).toBe(true)
+  expect(engine.requiresDownload()).toBe(false)
+  await engine.initialize(initCallback)
+  expect(initCallback).toHaveBeenLastCalledWith({ task: 'soniox', status: 'ready', model: expect.any(String) })
   await expect(engine.transcribe(new Blob())).rejects.toThrowError()
 })
 


### PR DESCRIPTION
## Summary
- expose Soniox as selectable STT engine without relying on temporary API keys
- streamline Soniox settings and expand unit tests for engine selection and settings UI

## Testing
- `npm install vitest --legacy-peer-deps` *(fails: connect ENETUNREACH)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a9f9f4088328bbeb7ccdd18b0b32