### PR TITLE
Switch Fireworks STT streaming to the V2 endpoint

### DIFF
--- a/src/voice/stt-fireworks.ts
+++ b/src/voice/stt-fireworks.ts
@@ -85,7 +85,7 @@ export default class STTFireworks implements STTEngine {
       return
     }
 
-    const baseWsUrl = 'wss://audio-streaming.us-virginia-1.direct.fireworks.ai'
+    const baseWsUrl = 'wss://audio-streaming-v2.api.fireworks.ai'
     const wsPath = '/v1/audio/transcriptions/streaming'
 
     const queryParams = new URLSearchParams()


### PR DESCRIPTION
## Summary
- update the Fireworks STT streaming client to use the V2 WebSocket host while keeping the existing transcription path

## Testing
- npm run lint *(fails: Cannot find package '@typescript-eslint/parser')*


------
https://chatgpt.com/codex/tasks/task_e_68efb0a46ea883288c64ff6039756cbd