### PR TITLE
Update Soniox STT endpoints to v3

### DIFF
--- a/src/voice/stt-soniox.ts
+++ b/src/voice/stt-soniox.ts
@@ -7,12 +7,12 @@ import { STTEngine, ProgressCallback, TranscribeResponse, StreamingCallback } fr
  * Soniox speech-to-text engine supporting both async and real-time transcription.
  * 
  * Async API:
- *   - POST /v1/transcriptions with direct audio data
- *   - GET /v1/transcriptions/{id} for status polling
- *   - GET /v1/transcriptions/{id}/transcript for final text
+ *   - POST /v3/transcriptions with direct audio data
+ *   - GET /v3/transcriptions/{id} for status polling
+ *   - GET /v3/transcriptions/{id}/transcript for final text
  *
  * Real-time API:
- *   - WebSocket wss://stt-rt.soniox.com/transcribe-websocket
+ *   - WebSocket wss://api.soniox.com/v3/streaming/speech-to-text
  *   - JSON config message followed by binary audio chunks
  *   - Receives tokens with is_final flag for progressive display
  */
@@ -93,7 +93,7 @@ export default class STTSoniox implements STTEngine {
         requestBody.context = vocabularyWords.join(', ')
       }
       
-      const response = await fetch('https://api.soniox.com/v1/transcriptions', {
+      const response = await fetch('https://api.soniox.com/v3/transcriptions', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${apiKey}`,
@@ -166,7 +166,7 @@ export default class STTSoniox implements STTEngine {
     const maxAttempts = 60 // 60 seconds max
     
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const statusResponse = await fetch(`https://api.soniox.com/v1/transcriptions/${transcriptionId}`, {
+      const statusResponse = await fetch(`https://api.soniox.com/v3/transcriptions/${transcriptionId}`, {
         headers: { 'Authorization': `Bearer ${apiKey}` }
       })
 
@@ -178,7 +178,7 @@ export default class STTSoniox implements STTEngine {
       
       if (statusData.status === 'completed') {
         // Get the final transcript
-        const transcriptResponse = await fetch(`https://api.soniox.com/v1/transcriptions/${transcriptionId}/transcript`, {
+        const transcriptResponse = await fetch(`https://api.soniox.com/v3/transcriptions/${transcriptionId}/transcript`, {
           headers: { 'Authorization': `Bearer ${apiKey}` }
         })
 
@@ -227,7 +227,7 @@ export default class STTSoniox implements STTEngine {
       console.log(`Uploading WebM with duration: ${(audioBlob as any)._audioDuration}ms`)
     }
     
-    const response = await fetch('https://api.soniox.com/v1/files', {
+    const response = await fetch('https://api.soniox.com/v3/files', {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${apiKey}`
@@ -253,7 +253,7 @@ export default class STTSoniox implements STTEngine {
 
   private async deleteUploadedFile(fileId: string, apiKey: string): Promise<void> {
     try {
-      await fetch(`https://api.soniox.com/v1/files/${fileId}`, {
+      await fetch(`https://api.soniox.com/v3/files/${fileId}`, {
         method: 'DELETE',
         headers: { 'Authorization': `Bearer ${apiKey}` }
       })
@@ -265,7 +265,7 @@ export default class STTSoniox implements STTEngine {
 
   private async cleanupTranscription(transcriptionId: string, apiKey: string): Promise<void> {
     try {
-      await fetch(`https://api.soniox.com/v1/transcriptions/${transcriptionId}`, {
+      await fetch(`https://api.soniox.com/v3/transcriptions/${transcriptionId}`, {
         method: 'DELETE',
         headers: { 'Authorization': `Bearer ${apiKey}` }
       })
@@ -295,7 +295,7 @@ export default class STTSoniox implements STTEngine {
     this.pendingError = null
     
     try {
-      this.ws = new WebSocket('wss://stt-rt.soniox.com/transcribe-websocket')
+      this.ws = new WebSocket('wss://api.soniox.com/v3/streaming/speech-to-text')
       
       this.ws.onopen = () => {
         // Send initial configuration message with correct audio format for WebSocket

--- a/tests/unit/stt-soniox.test.ts
+++ b/tests/unit/stt-soniox.test.ts
@@ -78,14 +78,14 @@ describe('STTSoniox', () => {
     
     // Verify file upload call
     const [uploadUrl, uploadOptions] = fetchMock.mock.calls[0]
-    expect(uploadUrl).toBe('https://api.soniox.com/v1/files')
+    expect(uploadUrl).toBe('https://api.soniox.com/v3/files')
     expect(uploadOptions.method).toBe('POST')
     expect(uploadOptions.headers['Authorization']).toBe('Bearer test-api-key')
     expect(uploadOptions.body).toBeInstanceOf(FormData)
     
     // Verify transcription creation call
     const [createUrl, createOptions] = fetchMock.mock.calls[1]
-    expect(createUrl).toBe('https://api.soniox.com/v1/transcriptions')
+    expect(createUrl).toBe('https://api.soniox.com/v3/transcriptions')
     expect(createOptions.method).toBe('POST')
     expect(createOptions.headers['Authorization']).toBe('Bearer test-api-key')
     
@@ -126,7 +126,7 @@ describe('STTSoniox', () => {
       onclose: any
       
       constructor(public url: string) {
-        expect(url).toBe('wss://stt-rt.soniox.com/transcribe-websocket')
+        expect(url).toBe('wss://api.soniox.com/v3/streaming/speech-to-text')
         
         setTimeout(() => {
           this.readyState = WebSocket.OPEN

--- a/tests/unit/stt.test.ts
+++ b/tests/unit/stt.test.ts
@@ -102,7 +102,7 @@ global.fetch = vi.fn(async (url: string | Request, init?: any) => {
   }
 
   // Soniox file upload
-  if (url.includes('api.soniox.com/v1/files') && init?.method === 'POST') {
+  if (url.includes('api.soniox.com/v3/files') && init?.method === 'POST') {
     return {
       ok: true,
       status: 200,
@@ -112,7 +112,7 @@ global.fetch = vi.fn(async (url: string | Request, init?: any) => {
   }
 
   // Soniox transcription creation  
-  if (url.includes('api.soniox.com/v1/transcriptions') && init?.method === 'POST') {
+  if (url.includes('api.soniox.com/v3/transcriptions') && init?.method === 'POST') {
     return {
       ok: true,
       status: 200,
@@ -122,7 +122,7 @@ global.fetch = vi.fn(async (url: string | Request, init?: any) => {
   }
 
   // Soniox status check
-  if (url.includes('api.soniox.com/v1/transcriptions/mock-soniox-transcription-id') && !url.includes('transcript')) {
+  if (url.includes('api.soniox.com/v3/transcriptions/mock-soniox-transcription-id') && !url.includes('transcript')) {
     return {
       ok: true,
       status: 200,
@@ -132,7 +132,7 @@ global.fetch = vi.fn(async (url: string | Request, init?: any) => {
   }
 
   // Soniox transcript retrieval
-  if (url.includes('api.soniox.com/v1/transcriptions/mock-soniox-transcription-id/transcript')) {
+  if (url.includes('api.soniox.com/v3/transcriptions/mock-soniox-transcription-id/transcript')) {
     return {
       ok: true,
       status: 200,


### PR DESCRIPTION
https://soniox.com/blog/2025-10-21-soniox-v3

## Summary
- switch the Soniox async transcription REST calls to the new v3 API routes
- point the real-time Soniox speech-to-text WebSocket client at the v3 streaming endpoint
- adjust unit tests to cover the updated Soniox API URLs

## Testing
- npm run lint *(fails: missing @typescript-eslint/parser)*
- npm test -- tests/unit/stt-soniox.test.ts *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f7e34b6f748328b61e615213396ee3